### PR TITLE
Add missing teardown method

### DIFF
--- a/source/MainWindow.cpp
+++ b/source/MainWindow.cpp
@@ -24,3 +24,9 @@ void MainWindow::init() {
   qInfo() << "Device initialized, starting render loop.";
   gpuWidget_->run();
 }
+
+void MainWindow::closeEvent(QCloseEvent* event) {
+  qInfo("MainWindow::closeEvent");
+  gpuWidget_->stop();
+  QMainWindow::closeEvent(event);
+}

--- a/source/MainWindow.h
+++ b/source/MainWindow.h
@@ -22,6 +22,8 @@ class MainWindow : public QMainWindow {
   void init();
 
  private:
+  void closeEvent(QCloseEvent* event) override;
+
   Ui::MainWindow* ui;
 
   QWGPUWidget* gpuWidget_;

--- a/source/QWGPUWidget.cpp
+++ b/source/QWGPUWidget.cpp
@@ -71,6 +71,12 @@ void QWGPUWidget::run() {
   start_time_ = std::chrono::steady_clock::now();
 }
 
+// Required for things to teardown properly:
+void QWGPUWidget::stop() {
+  disconnect(&frame_timer_, &QTimer::timeout, this, &QWGPUWidget::onFrameTimerFired);
+  frame_timer_.stop();
+}
+
 // Start a render pass by clearing depth + RGB.
 wgpu::RenderPassEncoder make_render_pass_encoder_with_targets(const wgpu::CommandEncoder& encoder,
                                                               const wgpu::TextureView& target_texture_view,
@@ -365,8 +371,10 @@ void QWGPUWidget::showEvent(QShowEvent* event) {
   QWidget::showEvent(event);
 }
 
-void QWGPUWidget::resizeEvent(QResizeEvent*) {
+void QWGPUWidget::resizeEvent(QResizeEvent* event) {
   if (context_) {
+    // Re-draw during resize or we get weird flickering on linux.
     onFrameTimerFired();
   }
+  QWidget::resizeEvent(event);
 }

--- a/source/QWGPUWidget.h
+++ b/source/QWGPUWidget.h
@@ -14,9 +14,9 @@ class QWGPUWidget : public QWidget {
 
  public:
   QWGPUWidget(QWidget* parent);
-  ~QWGPUWidget() = default;
 
   void run();
+  void stop();
 
  signals:
   void deviceInitialized();


### PR DESCRIPTION
Explicitly stop the render loop when the window closes, or the app won't exit properly.